### PR TITLE
[liburing] Expose `io_uring_prep_sendmsg`

### DIFF
--- a/inlined.c
+++ b/inlined.c
@@ -19,6 +19,11 @@ void io_uring_prep_send_(struct io_uring_sqe *sqe, int sockfd, const void *buf, 
     io_uring_prep_send(sqe, sockfd, buf, len, flags);
 }
 
+void io_uring_prep_sendmsg_(struct io_uring_sqe *sqe, int fd, const struct msghdr *msg, unsigned flags)
+{
+    io_uring_prep_sendmsg(sqe, fd, msg, flags);
+}
+
 void io_uring_prep_sendto_(struct io_uring_sqe *sqe, int sockfd, const void *buf, size_t len, int flags,
                            const struct sockaddr *dest_addr, socklen_t addrlen)
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ extern "C" {
         addrlen: socklen_t,
     );
 
+    fn io_uring_prep_sendmsg_(sqe: *mut io_uring_sqe, sockfd: c_int, msg: *const msghdr, flags: c_int);
+
     fn io_uring_prep_recv_(sqe: *mut io_uring_sqe, sockfd: c_int, buf: *mut c_void, len: usize, flags: c_int);
 
     fn io_uring_wait_cqe_(ring: *mut io_uring, cqe_ptr: *mut *mut io_uring_cqe) -> c_int;
@@ -79,6 +81,11 @@ pub unsafe fn io_uring_prep_sendto(
     addrlen: socklen_t,
 ) {
     io_uring_prep_sendto_(sqe, sockfd, buf, len, flags, sockaddr, addrlen);
+}
+
+#[inline]
+pub unsafe fn io_uring_prep_sendmsg(sqe: *mut io_uring_sqe, sockfd: c_int, msg: *const msghdr, flags: c_int) {
+    io_uring_prep_sendmsg_(sqe, sockfd, msg, flags);
 }
 
 #[inline]


### PR DESCRIPTION
Description
========

In this PR I expose the underlying `io_uring_prep_sendmsg()` operation from Liburing.