### PR TITLE
[build] Drop Allow on Deref Null Pointer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 #![allow(improper_ctypes)]
-#![allow(deref_nullptr)]
 
 //==============================================================================
 // Imports


### PR DESCRIPTION
Description
-------------

This PR is related to https://github.com/demikernel/liburing-rs/issues/4.

Summary of Changes
------------------------

- Removed `#![allow(deref_nullptr)` clause to make warnings visible.